### PR TITLE
Add redirect for youtube

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -278,6 +278,11 @@ class App < Sinatra::Base
     end
   end
 
+  # For Youtube
+  get '/ondemand/*' do
+    redirect "https://ondemand.lewagon.org/#{request.fullpath.gsub("/ondemand/", "")}"
+  end
+
   not_found do
     erb :not_found
   end


### PR DESCRIPTION
@cedricmenteau: Une fois mergé, tu peux transformer cette url:

https://**ondemand**.lewagon.org/tracks/codez-votre-premier-site-web/go?utm_source=youtube

en

http://**www**.lewagon.org**/ondemand**/tracks/codez-votre-premier-site-web/go?utm_source=youtube

et la redirection va fonctionner, en preservant le path et les `utm`