### PR TITLE
LA conversion tracking

### DIFF
--- a/data/camps.yml
+++ b/data/camps.yml
@@ -202,6 +202,8 @@ losangeles-october-2015:
   currency: $
   currency_iso: USD
   language: en
+  facebook_tracking_ids:
+    - 6029555810828
   trello:
     inbox_list_id: 5566cb5725f4b4031ac12bb9
 


### PR DESCRIPTION
@its-just-yo I added your conversion tracking pixel.

Just a remark, we have been tested Conversion-Optimized ads with Facebook a lot for FullStack and OnDemand and the conclusion is that they just don't work with the small traffic we have.

So with @cedricmenteau we reverted to regular ads to bring traffic to the site.

I can merge this PR if you still want to with the conversion ads.
